### PR TITLE
Refactor stylesheets

### DIFF
--- a/_resources/odmlDocument.xsl
+++ b/_resources/odmlDocument.xsl
@@ -138,6 +138,7 @@
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
+              <th><font size="+1" color="white"><b>Uncertainty</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
@@ -153,6 +154,7 @@
                 <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
+                <td width="5%"><p><xsl:value-of select="uncertainty"/><br/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/_resources/odmlTemplate.xsl
+++ b/_resources/odmlTemplate.xsl
@@ -3,7 +3,9 @@
                 xmlns:fn="http://www.w3.org/2005/02/xpath-functions"
                 xmlns:odml="http://www.g-node.org/odml">
 
-  <!-- This stylesheet is meant to view an odML document in a web browser -->
+  <!-- This stylesheet is meant to view odml-templates in a web browser -->
+  <!-- Please note: only template related elements will be displayed -->
+  <!-- Elements like uncertainty, id or value will not be shown -->
   <!-- ************************************************  -->
   <!--                   root template                   -->
   <xsl:template match="odML">
@@ -12,16 +14,16 @@
     <html>
       <head>
         <meta charset="utf-8" />
-        <title>odML | The Open metaData Markup Language</title>
+        <title>odML | Open metadata markup language - Templates and Terminologies -</title>
         <meta name="description"
-              content="Markup language for the storage of scientific metadata" />
+              content="Templates and Terminologies for the storage of scientific metadata" />
         <link rel="stylesheet" href="https://templates.g-node.org/_resources/odml_style.css" />
         <link rel="icon" href="https://templates.g-node.org/_resources/odMLIcon.ico" />
       </head>
 
       <body>
         <header>
-          <h1><a class="white" href="https://templates.g-node.org/templates.xml">odML metadata document</a></h1>
+          <h1><a class="white" href="https://templates.g-node.org/templates.xml">odML metadata template</a></h1>
         </header>
 
         <div class="navWrapper">

--- a/blackrock/blackrock.xml
+++ b/blackrock/blackrock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlDocument.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlTemplate.xsl"?>
 <odML version="1.1">
   <version>1.0</version>
   <author>Lyuba Zehl</author>

--- a/datacite/datacite.xml
+++ b/datacite/datacite.xml
@@ -22,56 +22,64 @@
 
     <section>
         <type>DataReference</type>
-        <name>DataCiteAuthor 1</name>
-        <definition>Information about an author as required by DataCite.</definition>
-        <property>
-            <name>FirstName</name>
-            <definition>The authors first Name (John).</definition>
-            <type>string</type>
-            <value></value>
-        </property>
-        <property>
-            <name>LastName</name>
-            <definition>The authors last name (Doe).</definition>
-            <type>string</type>
-            <value></value>
-        </property>
-        <property>
-            <name>Affiliation</name>
-            <definition>Affiliation of the author [Institute, City, Country]</definition>
-            <type>string</type>
-            <value></value>
-        </property>
-        <property>
-            <name>Id</name>
-            <definition>Any Id that is capable of identifying the author e.g. ORCID</definition>
-            <type>string</type>
-            <value></value>
-        </property>
+        <name>DataCiteAuthors</name>
+        <section>
+            <name>DataCiteAuthor 1</name>
+            <type>DataReference</type>
+            <definition>Information about an author as required by DataCite.</definition>
+            <property>
+                <name>FirstName</name>
+                <definition>The authors first Name (John).</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+            <property>
+                <name>LastName</name>
+                <definition>The authors last name (Doe).</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+            <property>
+                <name>Affiliation</name>
+                <definition>Affiliation of the author [Institute, City, Country]</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+            <property>
+                <name>Id</name>
+                <definition>Any Id that is capable of identifying the author e.g. ORCID</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+        </section>
     </section>
 
     <section>
         <type>DataReference</type>
-        <name>DataCiteReference 1</name>
-        <definition>A publication the published dataset is referencing.</definition>
-        <property>
-            <name>DOI</name>
-            <definition>DOI to the referenced publication</definition>
-            <type>string</type>
-            <value></value>
-        </property>
-        <property>
-            <name>RefType</name>
-            <definition>refType might be: IsCitedBy, IsSupplementTo, IsReferencedBy, IsPartOf for further valid types see https://schema.datacite.org/meta/kernel-4</definition>
-            <type>string</type>
-            <value></value>
-        </property>
-        <property>
-            <name>PublictionCitation</name>
-            <definition>Full citation of the reference publication</definition>
-            <type>string</type>
-            <value></value>
-        </property>
+        <name>DataCiteReferences</name>
+        <section>
+            <type>DataReference</type>
+            <name>DataCiteReference 1</name>
+            <definition>A publication the published dataset is referencing.</definition>
+            <property>
+                <name>DOI</name>
+                <definition>DOI to the referenced publication</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+            <property>
+                <name>RefType</name>
+                <definition>refType might be: IsCitedBy, IsSupplementTo, IsReferencedBy, IsPartOf for further valid types see https://schema.datacite.org/meta/kernel-4</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+            <property>
+                <name>PublictionCitation</name>
+                <definition>Full citation of the reference publication</definition>
+                <type>string</type>
+                <value></value>
+            </property>
+        </section>
     </section>
 
     <section>

--- a/datacite/datacite.xml
+++ b/datacite/datacite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlDocument.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlTemplate.xsl"?>
 <odML version="1.1">
   <section>
     <type>DataReference</type>

--- a/eeg-setup/eeg-basil.xml
+++ b/eeg-setup/eeg-basil.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlDocument.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlTemplate.xsl"?>
 <odML version="1.1">
     <date>2019-03-28</date>
     <author>Petr Jezek</author>

--- a/eeg-setup/eeg-car-sim.xml
+++ b/eeg-setup/eeg-car-sim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlDocument.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlTemplate.xsl"?>
 <odML version="1.1">
     <date>2019-03-28</date>
     <author>Petr Jezek</author>

--- a/eeg-setup/eeg-response.xml
+++ b/eeg-setup/eeg-response.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlDocument.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlTemplate.xsl"?>
 <odML version="1.1">
     <date>2019-03-28</date>
     <author>Petr Jezek</author>

--- a/templates.xml
+++ b/templates.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://templates.g-node.org/_resources/odmlTemplatesIndex.xsl"?>
 <odML version="1.1">
+  <version>1.0</version>
+  <date>2019-09-17</date>
+  <author>German Neuroinformatics Node</author>
+
   <section>
     <type>template</type>
     <name>Blackrock</name>


### PR DESCRIPTION
There are now two different stylesheets in the `_resources` folder to render odML files.

- `odmlTemplate.xsl` has been added and is used to render all template files.
- `odmlDocument.xsl` has been updated to render actual odML files containing values and uncertainty.
